### PR TITLE
Walk around Travis Configuration Issue on Ubuntu 16.04 by Using Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
         docker exec test apt-get install -y git pkg-config build-essential clang libapr1-dev libaprutil1-dev libboost-all-dev libyaml-cpp-dev python-dev python-pip libgoogle-perftools-dev;
       fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-        docker exec test pip install -r requirements.txt;
+        docker exec test pip install tabulate;
       fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,36 +2,44 @@ matrix:
     include:
         - os: osx
         - os: linux
-          dist: xenial
+          dist: trusty
           sudo: required
+          services: docker
 
 language: cpp
-
-addons:
-    apt:
-        packages:
-            - pkg-config
-            - build-essential
-            - clang
-            - libapr1-dev
-            - libaprutil1-dev
-            - libboost-all-dev
-            - libyaml-cpp-dev
-            - python-dev
-            - python-pip
-            - libgoogle-perftools-dev
 
 before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install boost || true; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install yaml-cpp || true; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+        brew install yaml-cpp || true;
+      fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python || true; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pip2 install tabulate; fi
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo pip2 install tabulate; fi
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y libboost-all-dev; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+        docker pull ubuntu:16.04;
+      fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+        docker run -w /root --name test -d ubuntu:16.04 sleep infinity;
+      fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+        docker cp . test:/root/janus;
+      fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+        docker exec test apt-get update -qq;
+      fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+        docker exec test apt-get install -y git pkg-config build-essential clang libapr1-dev libaprutil1-dev libboost-all-dev libyaml-cpp-dev python-dev python-pip libgoogle-perftools-dev;
+      fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+        docker exec test pip install -r requirements.txt;
+      fi
 
 install:
 
 script:
-    - ./waf configure build
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./waf configure build; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+        docker exec test ./waf configure build;
+      fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python || true; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pip2 install tabulate; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo pip2 install tabulate; fi
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo sudo apt-get install -y libboost-all-dev; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y libboost-all-dev; fi
 
 install:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python || true; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pip2 install tabulate; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo pip2 install tabulate; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo sudo apt-get install -y libboost-all-dev; fi
 
 install:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,6 @@ install:
 script:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./waf configure build; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-        docker exec test ./waf configure build;
+        docker exec test sh -c 'cd janus && ./waf configure build';
       fi
 


### PR DESCRIPTION
Travis CI currently has issue on apt-get under xenial that we cannot install packages.
Use docker as a walk-around.